### PR TITLE
+ Make rustc_http::Client public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod response;
 // public re-exports
 pub type Result<T> = std::result::Result<T, error::Error>;
 pub use crate::client::new_client;
+pub use crate::client::Client;
 pub use crate::cookie::Cookie;
 pub use crate::error::Error;
 pub use crate::response::Response;


### PR DESCRIPTION
I would like to be able to wrap `Client` in my own struct in my test code to extend it with functionality. This is not possible because `rustc_http::Client` is not part of the public API.