### PR TITLE
+ Allow building client with custom reqwest::ClientBuilder

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -22,9 +22,20 @@ impl Client {
 }
 
 pub fn new_client(base_url: impl Into<BaseUrl>) -> Result<Client> {
+	let reqwest_builder = reqwest::Client::builder();
+
+	new_client_with_reqwest(base_url, reqwest_builder)
+}
+
+pub fn new_client_with_reqwest(
+	base_url: impl Into<BaseUrl>,
+	reqwest_builder: reqwest::ClientBuilder,
+) -> Result<Client> {
 	let base_url = base_url.into().into();
 	let cookie_store = Arc::new(CookieStoreMutex::default());
-	let reqwest_client = reqwest::Client::builder().cookie_provider(cookie_store.clone()).build()?;
+	let reqwest_client = reqwest_builder
+		.cookie_provider(cookie_store.clone())
+		.build()?;
 
 	Ok(Client {
 		base_url,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod response;
 // public re-exports
 pub type Result<T> = std::result::Result<T, error::Error>;
 pub use crate::client::new_client;
+pub use crate::client::new_client_with_reqwest;
 pub use crate::cookie::Cookie;
 pub use crate::error::Error;
 pub use crate::response::Response;


### PR DESCRIPTION
I would like to be able to configure the underlying Reqwest instance, which is not possible in the current setup.

This PR adds the `new_client_with_reqwest` function to allow passing in a `reqwest::ClientBuilder` instance which has been customised.