### PR TITLE
update colored_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2021"
 authors = ["Jeremy Chone <jeremy.chone@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Minimalistic HTTP Client Test Utilities"
-categories = ["development-tools::testing", "network-programming", "web-programming::http-client" ]
-keywords = [
-	"test",
-	"http-client"
+categories = [
+	"development-tools::testing",
+	"network-programming",
+	"web-programming::http-client",
 ]
+keywords = ["test", "http-client"]
 homepage = "https://github.com/jeremychone/rust-httpc-test"
 repository = "https://github.com/jeremychone/rust-httpc-test"
 
@@ -19,12 +20,12 @@ color-output = ["url", "colored_json", "colored"]
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 thiserror = "1"
-reqwest = {version = "0.11", features = ["cookies", "json"]}
+reqwest = { version = "0.11", features = ["cookies", "json"] }
 reqwest_cookie_store = "0.6"
 http = "0.2"
 # Note: It seems request_cookie_store doe snot support cookie 0.18
-#       So, sticking with 0.17 for now. 
-cookie = "0.17" 
+#       So, sticking with 0.17 for now.
+cookie = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
@@ -37,7 +38,7 @@ version = "2.4.0"
 optional = true
 
 [dependencies.colored_json]
-version = "3.3"
+version = "4.1"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Hi,
thanks for your great work!
Wanted to try the `["color-output"]` which gave me the following error.
![CleanShot 2023-11-16 at 15 18 04@2x](https://github.com/jeremychone/rust-httpc-test/assets/20935138/df4b2c49-16d5-4896-9297-73ed67e89f56)
Hope the change to `[dependencies.colored_json]
version = "4.1"` fixes it.
