### PR TITLE
fix status code string appears twice

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -207,7 +207,7 @@ impl Response {
 		println!(
 			"=> {:<15}: {} {}",
 			"Status",
-			self.status,
+			self.status.as_str(),
 			self.status.canonical_reason().unwrap_or_default()
 		);
 


### PR DESCRIPTION
Fix status string in response message appears twice if color-output feature is not enabled.

```
=== Response for POST http://localhost:3000/api/login
=> Status         : 200 OK OK
```
->
```
=== Response for POST http://localhost:3000/api/login
=> Status         : 200 OK
```
